### PR TITLE
Add GetValidatedConfigurationSection<T>()

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,11 @@ There is now an experimental extension method that will eagerly validate the obj
 
 This method is useful where a particular software package does not properly support being wired up via IoC in .NET Core.  A symptom of this is where the package expects you to create a settings/options object and pass it into its extension method in `Startup.ConfigureServices()`.
 
-#### Caveats:
+NOTE: There is a better method for application startup when you just want a snapshot of the configuration.  It does not register an `IOptions<T>` instances in the DI provider.
+
+    var appSettings = Configuration.GetValidatedConfigurationSection<ExampleAppSettings>();
+                        
+#### AddEagerlyValidatedSettings Caveats:
 
 - Settings are only bound once from the configuration file at startup.
 - The `IOptionsMonitor<T>` will not notice when the underlying configuration values change.

--- a/RELEASE-PROCESS.md
+++ b/RELEASE-PROCESS.md
@@ -1,0 +1,15 @@
+# Release Process
+
+## Nuget API key
+
+1. Check expirations of API keys at https://www.nuget.org/account/apikeys
+2. Regenerate key if necessary.
+3. GitHub, repository settings, Secrets...
+4. Update the Nuget API key with the new value.
+
+## Create Tag
+
+1. Create an [annotated git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) on the commit for the release. Such as `$ git tag -a v1.1.0 -m "Release v1.1.0"`
+2. Push the tag to the repository.
+3. An automatic build and release will occur.
+

--- a/examples/OptionsPatternMvc.Example/Startup.cs
+++ b/examples/OptionsPatternMvc.Example/Startup.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -21,6 +22,9 @@ namespace OptionsPatternMvc.Example
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddValidatedSettings<ExampleAppSettings>(Configuration);
+
+            var directExampleAppSettings = Configuration.GetValidatedConfigurationSection<ExampleAppSettings>();
+            Console.WriteLine($"Name={directExampleAppSettings.Name}");
             
             services.AddControllers();
         }

--- a/src/OptionsPatternValidation/ConfigurationExtensions.cs
+++ b/src/OptionsPatternValidation/ConfigurationExtensions.cs
@@ -1,0 +1,37 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using OptionsPatternValidation.ValidationOptions;
+
+namespace OptionsPatternValidation
+{
+    /// <summary>Extension for <see cref="IConfiguration"/> to fetch and validate a section
+    /// of the configuration into a strongly-typed object.  The fetched values are a
+    /// snapshot of the configuration section at the time of the call.
+    /// </summary>
+    public static class ConfigurationExtensions
+    {
+        /// <summary>Fetch and validate a section of the current configuration values.</summary>
+        /// <param name="configuration">The <see cref="IConfiguration"/> object.</param>
+        /// <typeparam name="T">The type of the settings object to bind the configuration to.</typeparam>
+        /// <exception cref="OptionsValidationException">The set of validation failures.</exception>
+        public static T GetValidatedConfigurationSection<T>(
+            this IConfiguration configuration
+            ) where T : class
+        {
+            var sectionName = SettingsSectionNameAttribute.GetSettingsSectionName<T>();
+            var configurationSection = configuration.GetSection(sectionName);
+            var settings = configurationSection.Get<T>();
+            
+            var validator = new RecursiveDataAnnotationValidateOptions<T>(null);
+            var validateOptionsResult = validator.Validate(null, settings);
+            if (validateOptionsResult.Failed)
+                throw new OptionsValidationException(
+                    $"Section: {sectionName}",
+                    typeof(T),
+                    validateOptionsResult.Failures
+                );
+
+            return settings;
+        }
+    }
+}

--- a/src/OptionsPatternValidation/ServiceCollectionExtensions.cs
+++ b/src/OptionsPatternValidation/ServiceCollectionExtensions.cs
@@ -63,7 +63,7 @@ namespace OptionsPatternValidation
 
         /// <summary><para>Bind a section of the appsettings.json to an options pattern POCO along
         /// with wiring up recursively-validated DataAnnotation validation.  It will immediately
-        /// validate the POCO after binding and throw an exception if validation fails.</para>
+        /// validate the POCO and throw an exception if validation fails.</para>
         /// <para>This method outputs a reference to the POCO, loaded with setting values
         /// at the time of registration.  This reference should be the same as the reference
         /// that you get back later from the IOptions.Value call.</para>
@@ -79,9 +79,7 @@ namespace OptionsPatternValidation
             out T outputOptions
             ) where T : class, new()
         {
-            var sectionName = SettingsSectionNameAttribute.GetSettingsSectionName<T>();
-            var configurationSection = configuration.GetSection(sectionName);
-            var settings = configurationSection.Get<T>();
+            var settings = configuration.GetValidatedConfigurationSection<T>();
             
             var options = Options.Create(settings);
             
@@ -90,15 +88,6 @@ namespace OptionsPatternValidation
                 new RecursiveDataAnnotationValidateOptions<T>(
                     null
                 ));
-
-            var validator = new RecursiveDataAnnotationValidateOptions<T>(null);
-            var validateOptionsResult = validator.Validate(null, options.Value);
-            if (validateOptionsResult.Failed)
-                throw new OptionsValidationException(
-                    $"Section: {sectionName}",
-                    typeof(T),
-                    validateOptionsResult.Failures
-                    );
             
             outputOptions = options.Value;
             

--- a/test/OptionsPatternValidation.Tests/ConfigurationExtensions/GetValidatedConfigurationSectionTests.cs
+++ b/test/OptionsPatternValidation.Tests/ConfigurationExtensions/GetValidatedConfigurationSectionTests.cs
@@ -1,0 +1,62 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using OptionsPatternValidation.Tests.Helpers;
+using OptionsPatternValidation.Tests.Settings.AttributeValidation;
+using Xunit;
+
+namespace OptionsPatternValidation.Tests.ConfigurationExtensions
+{
+    public class GetValidatedConfigurationSectionTests
+    {
+        [Fact]
+        public void Wires_up_settings_from_string()
+        {
+            var services = new ServiceCollection();
+            
+            const string json = @"
+{
+""AttributeValidated"": {
+    ""IntegerA"": 53,
+    ""BooleanB"": false
+  }
+}
+                ";
+
+            var configuration = ConfigurationTestBuilder.BuildFromJsonString(json);
+
+            var result = configuration.GetValidatedConfigurationSection<AttributeValidatedSettings>();
+            
+            services.AddValidatedSettings<AttributeValidatedSettings>(configuration);
+
+            Assert.NotNull(result);
+            Assert.Equal(53, result.IntegerA);
+            Assert.False(result.BooleanB);
+        }
+        
+        [Fact]
+        public void Catches_validation_error_from_string()
+        {
+            var services = new ServiceCollection();
+            
+            const string json = @"
+{
+""AttributeValidated"": {
+    ""IntegerA"": 153,
+    ""BooleanB"": false
+  }
+}
+                ";            
+            
+            var configuration = ConfigurationTestBuilder.BuildFromJsonString(json);
+
+            void Act()
+            {
+                var _ = configuration.GetValidatedConfigurationSection<AttributeValidatedSettings>();
+            }
+
+            var exception = Assert.Throws<OptionsValidationException>(Act);
+            Assert.StartsWith("Validation failed for members: 'IntegerA'", exception.Message);
+        }
+    }
+}


### PR DESCRIPTION
Refactor code to pull out some logic that reads configuration, binds it to a C# object and then runs validation.  That gives an intermediate step between using `AddValidatedSettings<T>(Configuration)` and `AddEagerlyValidatedSettings<T>(Configuration, out)`.  The latter method attempts to do too much and registers something that is not compatible with `IOptionsMonitor<T>`.

### Usage Example:

`var appSettings = Configuration.GetValidatedConfigurationSection<ExampleAppSettings>();`

This can be used anywhere in the application startup process for when you want a snapshot of the configuration as it exists at that point in time.  But you also want validation of the configuration to happen before your code continues.

The disadvantage is that you will end up running validation multiple times during startup, unless you pass this object around.  But since the validation should be lightweight, it probably won't make a noticeable impact in practice.