### PR TITLE
If section not found, still new up the object

### DIFF
--- a/src/OptionsPatternValidation/ConfigurationExtensions.cs
+++ b/src/OptionsPatternValidation/ConfigurationExtensions.cs
@@ -16,11 +16,11 @@ namespace OptionsPatternValidation
         /// <exception cref="OptionsValidationException">The set of validation failures.</exception>
         public static T GetValidatedConfigurationSection<T>(
             this IConfiguration configuration
-            ) where T : class
+            ) where T : class, new()
         {
             var sectionName = SettingsSectionNameAttribute.GetSettingsSectionName<T>();
             var configurationSection = configuration.GetSection(sectionName);
-            var settings = configurationSection.Get<T>();
+            var settings = configurationSection.Get<T>() ?? new T();
             
             var validator = new RecursiveDataAnnotationValidateOptions<T>(null);
             var validateOptionsResult = validator.Validate(null, settings);

--- a/test/OptionsPatternValidation.Tests/ConfigurationExtensions/GetValidatedConfigurationSectionTests.cs
+++ b/test/OptionsPatternValidation.Tests/ConfigurationExtensions/GetValidatedConfigurationSectionTests.cs
@@ -12,8 +12,6 @@ namespace OptionsPatternValidation.Tests.ConfigurationExtensions
         [Fact]
         public void Wires_up_settings_from_string()
         {
-            var services = new ServiceCollection();
-            
             const string json = @"
 {
 ""AttributeValidated"": {
@@ -27,8 +25,6 @@ namespace OptionsPatternValidation.Tests.ConfigurationExtensions
 
             var result = configuration.GetValidatedConfigurationSection<AttributeValidatedSettings>();
             
-            services.AddValidatedSettings<AttributeValidatedSettings>(configuration);
-
             Assert.NotNull(result);
             Assert.Equal(53, result.IntegerA);
             Assert.False(result.BooleanB);
@@ -37,8 +33,6 @@ namespace OptionsPatternValidation.Tests.ConfigurationExtensions
         [Fact]
         public void Catches_validation_error_from_string()
         {
-            var services = new ServiceCollection();
-            
             const string json = @"
 {
 ""AttributeValidated"": {
@@ -57,6 +51,28 @@ namespace OptionsPatternValidation.Tests.ConfigurationExtensions
 
             var exception = Assert.Throws<OptionsValidationException>(Act);
             Assert.StartsWith("Validation failed for members: 'IntegerA'", exception.Message);
+        }
+        
+        [Fact]
+        public void If_section_not_in_configuration_new_up_the_object()
+        {
+            const string json = @"
+{
+""AttributeValidated"": {
+    ""IntegerA"": 73,
+    ""BooleanB"": false
+  }
+}
+                ";
+
+            var configuration = ConfigurationTestBuilder.BuildFromJsonString(json);
+
+            var result = configuration.GetValidatedConfigurationSection<AttributeValidatedWithDefaults>();
+            
+            Assert.NotNull(result);
+            Assert.Equal(35, result.IntegerA);
+            Assert.True(result.BooleanB);
+            Assert.NotEmpty(result.ConnectionString);
         }
     }
 }

--- a/test/OptionsPatternValidation.Tests/Settings/AttributeValidation/AttributeValidatedSettings.cs
+++ b/test/OptionsPatternValidation.Tests/Settings/AttributeValidation/AttributeValidatedSettings.cs
@@ -12,5 +12,8 @@ namespace OptionsPatternValidation.Tests.Settings.AttributeValidation
         
         [Required]
         public bool? BooleanB { get; set; }
+        
+        [Required]
+        public string ConnectionString { get; set; } = "some-sensible-default";
     }
 }

--- a/test/OptionsPatternValidation.Tests/Settings/AttributeValidation/AttributeValidatedWithDefaults.cs
+++ b/test/OptionsPatternValidation.Tests/Settings/AttributeValidation/AttributeValidatedWithDefaults.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace OptionsPatternValidation.Tests.Settings.AttributeValidation
+{
+    /// <summary>This POCO tests out DataAnnotation validation and every
+    /// property should have some form of validation attribute. But
+    /// the default values for the properties should pass validation.</summary>
+    public class AttributeValidatedWithDefaults
+    {
+        [Required, Range(1, 100)]
+        public int? IntegerA { get; set; } = 35;
+        
+        [Required]
+        public bool? BooleanB { get; set; } = true;
+            
+        [Required]
+        public string ConnectionString { get; set; } = "some-connection-string";
+    }
+}


### PR DESCRIPTION
If the settings section is not found in the configuration providers
at all, we should still new() up the POCO in hopes that it has 
sensible default values that will pass validation.