### PR TITLE
Package upgrades - Jun 2022

### DIFF
--- a/examples/OptionsPatternMvc.Dapper/OptionsPatternMvc.Dapper.csproj
+++ b/examples/OptionsPatternMvc.Dapper/OptionsPatternMvc.Dapper.csproj
@@ -7,9 +7,9 @@
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
-    <PackageReference Include="FluentMigrator" Version="3.3.1" />
-    <PackageReference Include="FluentMigrator.Runner" Version="3.3.1" />
-    <PackageReference Include="System.Data.SQLite.Core" Version="1.0.115.5" />
+    <PackageReference Include="FluentMigrator" Version="3.3.2" />
+    <PackageReference Include="FluentMigrator.Runner" Version="3.3.2" />
+    <PackageReference Include="System.Data.SQLite.Core" Version="1.0.116" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OptionsPatternValidation/OptionsPatternValidation.csproj
+++ b/src/OptionsPatternValidation/OptionsPatternValidation.csproj
@@ -15,10 +15,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.20" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.20" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.20" />
-    <PackageReference Include="RecursiveDataAnnotationsValidation" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.25" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.25" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.25" />
+    <PackageReference Include="RecursiveDataAnnotationsValidation" Version="1.1.1" />
   </ItemGroup>
 
 </Project>

--- a/test/OptionsPatternValidation.Tests/OptionsPatternValidation.Tests.csproj
+++ b/test/OptionsPatternValidation.Tests/OptionsPatternValidation.Tests.csproj
@@ -11,16 +11,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.22" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.22" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.22" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.25" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.25" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.25" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
- Microsoft.Extensions* packages 3.1.20 -> 3.1.25
- RecursiveDataAnnotationsValidation 1.1.0 -> 1.1.1
- Other package upgrades in test/example projects

While the ".Tests" project has a dependency on an old Newtonsoft.Json (v9)
package (which is vulnerable); there's no need to upgrade it specifically
to v13.0.1.