### PR TITLE
Pull the README.md for 'pack' from right spot

### DIFF
--- a/src/OptionsPatternValidation/OptionsPatternValidation.csproj
+++ b/src/OptionsPatternValidation/OptionsPatternValidation.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="README.md" />
+    <None Include="README.md" Pack="true" PackagePath="../../README.md" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This repo does things differently and runs 'dotnet pack' from the same folder as the csproj file.  So I need to reference the README.md file from the parent/parent.